### PR TITLE
Preserving saved regs.

### DIFF
--- a/base64_decode.S
+++ b/base64_decode.S
@@ -1,7 +1,7 @@
 #include <mips/regdef.h>
 #include <sys/syscall.h>
 
-#define STACK_FRAME_SIZE 24
+#define STACK_FRAME_SIZE 32
 
 .text
 .abicalls
@@ -10,8 +10,6 @@
 .globl 		base64_decode
 .ent 		base64_decode
 
-.frame      $fp, STACK_FRAME_SIZE, ra
-
 .set 		noreorder
 .cpload 	t9
 .set 		reorder
@@ -19,9 +17,11 @@
 base64_decode:	
     subu 	sp,  sp, STACK_FRAME_SIZE
 
-    .cprestore 16
-	sw 	    $fp, (STACK_FRAME_SIZE - 12)(sp)
-	sw 	    ra,  (STACK_FRAME_SIZE -  8)(sp)
+    sw      gp,  (STACK_FRAME_SIZE - 24)(sp)
+	sw 	    $fp, (STACK_FRAME_SIZE - 20)(sp)
+	sw 	    ra,  (STACK_FRAME_SIZE - 16)(sp)
+    sw      s2,  (STACK_FRAME_SIZE - 12)(sp)
+    sw      s3,  (STACK_FRAME_SIZE - 8)(sp)
 
 	move    $fp, sp
 
@@ -248,14 +248,14 @@ write_output:
 
 exit_base64_decode:
 	
-	# restore callee-saved registers
+	lw  a1,  (STACK_FRAME_SIZE +  4)(sp)
+    lw 	a0,  (STACK_FRAME_SIZE	   )(sp)
 
-	lw 	a1,  (STACK_FRAME_SIZE +  4)(sp)
-	lw 	a0,  (STACK_FRAME_SIZE	   )(sp)
-
-	lw 	gp,  (STACK_FRAME_SIZE - 16)(sp)
-	lw 	$fp, (STACK_FRAME_SIZE - 12)(sp)
-	lw 	ra,  (STACK_FRAME_SIZE -  8)(sp)
+	lw 	gp,  (STACK_FRAME_SIZE - 24)(sp)
+	lw 	$fp, (STACK_FRAME_SIZE - 20)(sp)
+	lw 	ra,  (STACK_FRAME_SIZE - 16)(sp)
+    lw  s3,  (STACK_FRAME_SIZE - 12)(sp)
+    lw  s2,  (STACK_FRAME_SIZE -  8)(sp)
 
 	addu 	sp,  sp, STACK_FRAME_SIZE
 

--- a/base64_decode.S
+++ b/base64_decode.S
@@ -36,6 +36,12 @@ read_input:
 	li	    v0, SYS_read
 	syscall
 
+    beq     a3, zero, continue_validation 
+    li      v0, 1
+    j       exit_base64_decode
+    
+
+continue_validation:
     li      s2, 0                     # Read byte count
     addu    s2, s2, v0
         
@@ -50,6 +56,11 @@ continue_read:
 	li	    v0, SYS_read
 	syscall
 
+    beq     a3, zero, continue_second_validation
+    li      v0, 1
+    j       exit_base64_decode
+    
+continue_second_validation:
     addu    s2, s2, v0
 
     lw      a0, (STACK_FRAME_SIZE)(sp)
@@ -58,6 +69,11 @@ continue_read:
 	li	    v0, SYS_read
 	syscall
 
+    beq     a3, zero, continue_third_validation
+    li      v0, 1
+    j       exit_base64_decode
+
+continue_third_validation:
     addu    s2, s2, v0
 
     lw	    a0, (STACK_FRAME_SIZE)(sp)
@@ -66,6 +82,11 @@ continue_read:
     li	    v0, SYS_read
     syscall
     
+    beq     a3, zero, continue_fourth_validation
+    li      v0, 1
+    j       exit_base64_decode
+    
+continue_fourth_validation:    
     addu    s2, s2, v0
         
     li      t1, 4                   
@@ -226,6 +247,11 @@ write_output:
 	li 	v0, SYS_write
 	syscall
 	
+    beq a3, 0, continue_write_val
+    li  v0, 1
+    j   exit_base64_decode
+    
+continue_write_val:
     li  t0, 2
     beq t0, s3, exit_base64_decode
     
@@ -235,6 +261,11 @@ write_output:
 	li 	v0, SYS_write
 	syscall
 
+    beq a3, 0, continue_second_write_val
+    li  v0, 1
+    j   exit_base64_decode
+    
+continue_second_write_val:
     li  t0, 1
     beq t0, s3, exit_base64_decode
 
@@ -244,6 +275,11 @@ write_output:
 	li 	v0, SYS_write
 	syscall
 
+    beq a3, 0, continue_loop
+    li  v0, 1
+    j   exit_base64_decode
+    
+continue_loop:
     j       read_input
 
 exit_base64_decode:

--- a/base64_encode.S
+++ b/base64_encode.S
@@ -20,7 +20,8 @@ base64_encode:
 	sw	gp,  (STACK_FRAME_SIZE - 16)(sp)
 	sw	$fp, (STACK_FRAME_SIZE - 12)(sp)
 	sw	ra,  (STACK_FRAME_SIZE -  8)(sp)
-
+    sw  s3,  (STACK_FRAME_SIZE -  4)(sp)
+    
 	move	$fp, sp
 
 	sw	a0,  (STACK_FRAME_SIZE     )(sp)
@@ -35,7 +36,7 @@ read_input:
 
     li    s3, 0
 
-   ## Read 1 char at time avoid endianess problems
+    ## Read 1 char at time avoid endianess problems
 
 	lw	a0, (STACK_FRAME_SIZE)(sp)
 	la	a1, input_buffer
@@ -179,14 +180,13 @@ verify_write:
 
 exit_base64_encode:
 
-	# restore callee-saved registers
-
 	lw	a1,  (STACK_FRAME_SIZE +  4)(sp)
 	lw	a0,  (STACK_FRAME_SIZE     )(sp)
 
 	lw	gp,  (STACK_FRAME_SIZE - 16)(sp)
 	lw	$fp, (STACK_FRAME_SIZE - 12)(sp)
 	lw	ra,  (STACK_FRAME_SIZE -  8)(sp)
+    lw  s3,  (STACK_FRAME_SIZE -  4)(sp)
 
 	addu	sp,  sp, STACK_FRAME_SIZE
 

--- a/base64_encode.S
+++ b/base64_encode.S
@@ -44,6 +44,12 @@ read_input:
 	li	v0, SYS_read
 	syscall
 
+    beq a3, 0, continue_validation
+    li  v0, 1
+    j   exit_base64_encode
+
+continue_validation:    
+
     beqz    v0, exit_base64_encode
     addiu   s3, s3, 1
 
@@ -53,6 +59,11 @@ read_input:
  	li	v0, SYS_read
  	syscall
 
+    beq a3, 0, continue_second_validation
+    li v0, 1
+    j   exit_base64_encode
+    
+continue_second_validation:
     beqz    v0, encode
     addiu   s3, s3, 1
 
@@ -62,14 +73,19 @@ read_input:
     li	v0, SYS_read
     syscall
 
+    beq a3, 0, continue_third_validation
+    li  v0, 1
+    j   exit_base64_encode
+
+continue_third_validation:
     beqz    v0, encode
     addiu   s3, s3, 1
 
     beq     v0, 0, exit_base64_encode
     addu    s0, v0, 0
 
-		bne			v0, -1, encode
-		li			v0, 1
+	bne			v0, -1, encode
+	li			v0, 1
 
 encode:
 
@@ -154,32 +170,49 @@ write_output:
 	li	v0, SYS_write
 	syscall
 
+    beq a3, 0, continue_write_val
+    li  v0, 1
+    j   exit_base64_encode
+
+continue_write_val:    
+
 	lw	a0, (STACK_FRAME_SIZE + 4)(sp)
 	la	a1, output_buffer + 1
 	li	a2, 1
 	li	v0, SYS_write
 	syscall
 
+    beq a3, 0, continue_write_second_val
+    li  v0, 1
+    j   exit_base64_encode
+    
+continue_write_second_val:    
 	lw	a0, (STACK_FRAME_SIZE + 4)(sp)
 	la	a1, output_buffer + 2
 	li	a2, 1
 	li	v0, SYS_write
 	syscall
 
+    beq a3, 0, continue_write_third_val
+    li  v0, 1
+    j   exit_base64_encode
+
+continue_write_third_val:
 	lw	a0, (STACK_FRAME_SIZE + 4)(sp)
 	la	a1, output_buffer + 3
 	li	a2, 1
 	li	v0, SYS_write
 	syscall
 
+    beq a3, 0, continue_write_fourth_val
+    li  v0, 1
+    j   exit_base64_encode
+    
+continue_write_fourth_val:
     li     t0, 3
     bge    t0, s3, read_input
 
-verify_write:
-	## TODO: Handle write errors ##
-
 exit_base64_encode:
-
 	lw	a1,  (STACK_FRAME_SIZE +  4)(sp)
 	lw	a0,  (STACK_FRAME_SIZE     )(sp)
 

--- a/make.sh
+++ b/make.sh
@@ -1,1 +1,2 @@
-gcc tp1.c argv_parser.c base64_encode.S -g -o tp1
+TP_NAME='tp1';
+gcc -pedantic -Wall -Werror -std=c99 $TP_NAME.c argv_parser.c base64_encode.S base64_decode.S -o $TP_NAME

--- a/tests/05-Encode-and-decode-with-no-changes.sh
+++ b/tests/05-Encode-and-decode-with-no-changes.sh
@@ -7,7 +7,12 @@ ENCODING_WORD='Man';
 OUTPUT=`echo -n $ENCODING_WORD | ./$TP_NAME`;
 DECODING_OUTPUT=`echo -n $OUTPUT | ./$TP_NAME -a decode`
 
-if [ $ENCODING_WORD == $DECODING_OUTPUT ]; then
+echo "$DECODING_OUTPUT" > tmp1
+echo "$ENCODING_WORD" > tmp2
+
+VALIDATE_STR=`diff tmp1 tmp2`;
+
+if [ !$VALIDATE_STR ]; then
   echo "$TEST_DESCRIPTION: OK";
 else
   echo "$TEST_DESCRIPTION: ERROR";


### PR DESCRIPTION
### Summary

* Uses padding to store `s3` in `encode`, expands stack frame size in `decode` to store `s3` and `s2`